### PR TITLE
Small Actions Fix

### DIFF
--- a/Buypartisan/Assets/Scripts/Action1Script.cs
+++ b/Buypartisan/Assets/Scripts/Action1Script.cs
@@ -152,7 +152,7 @@ public class Action1Script : MonoBehaviour {
 		zDis = Mathf.Abs (transform.position.z - currentPos.z);
 		distance = xDis + yDis + zDis;
 		
-		currentCost = moneyRequired * Mathf.RoundToInt (Mathf.Pow (costMultiplier, (distance - 1)));
+		currentCost = (moneyRequired + (moneyRequired * this.transform.parent.GetComponent<PlayerTurnsManager> ().costMultiplier)) * Mathf.RoundToInt (Mathf.Pow (costMultiplier, (distance - 1)));
 	}
 
 	void EndAction() {

--- a/Buypartisan/Assets/Scripts/Action2Script.cs
+++ b/Buypartisan/Assets/Scripts/Action2Script.cs
@@ -171,6 +171,7 @@ public class Action2Script : MonoBehaviour {
 	void EndAction() {
 		uiController.GetComponent<UI_Script>().toggleActionButtons();
 		this.transform.parent.GetComponent<PlayerTurnsManager> ().costMultiplier += 1;
+		players [currentPlayer].GetComponent<PlayerVariables> ().money -= moneyRequired + (moneyRequired * this.transform.parent.GetComponent<PlayerTurnsManager> ().costMultiplier);
 		Destroy(gameObject);
 	}
 }

--- a/Buypartisan/Assets/Scripts/Action4Script.cs
+++ b/Buypartisan/Assets/Scripts/Action4Script.cs
@@ -205,6 +205,7 @@ public class Action4Script : MonoBehaviour {
 	void EndAction() {
 		uiController.GetComponent<UI_Script>().toggleActionButtons();
 		this.transform.parent.GetComponent<PlayerTurnsManager> ().costMultiplier += 1;
+		players [currentPlayer].GetComponent<PlayerVariables> ().money -= moneyRequired + (moneyRequired * this.transform.parent.GetComponent<PlayerTurnsManager> ().costMultiplier);
 		Destroy(gameObject);
 	}
 }

--- a/Buypartisan/Assets/Scripts/ActionScriptTemplate.cs
+++ b/Buypartisan/Assets/Scripts/ActionScriptTemplate.cs
@@ -56,6 +56,7 @@ public class ActionScriptTemplate : MonoBehaviour {
 	void EndAction() {
 		uiController.GetComponent<UI_Script>().toggleActionButtons();
 		this.transform.parent.GetComponent<PlayerTurnsManager> ().costMultiplier += 1;
+		players [currentPlayer].GetComponent<PlayerVariables> ().money -= moneyRequired + (moneyRequired * this.transform.parent.GetComponent<PlayerTurnsManager> ().costMultiplier);
 		Destroy(gameObject);
 	}
 }


### PR DESCRIPTION
Actions now subtract their cost from the player playing the action, including any multipliers (e.g. making multiple actions per turn. Or for action1, moving more than one square).
