### PR TITLE
Title Screen Settings Minor Change

### DIFF
--- a/Buypartisan/Assets/TitleScreenUIScript.cs
+++ b/Buypartisan/Assets/TitleScreenUIScript.cs
@@ -108,6 +108,22 @@ public class TitleScreenUIScript : MonoBehaviour
 			if(toggleGridSize[i].isOn == true)
 			{
 				gridSize = i + 3;
+
+				//adjusts the max value of the slider so that user cannot have a 3X3X3 grid with more than 27 voters (Alex Jungroth)
+				if(i == 0)
+				{
+					if(voterCounterSlider.GetComponent<Slider>().value > 27)
+					{
+						//prevents the settings from defaulting to 27 if the user picks a 3X3X3 grid and a voter total greater than 27 (Alex Jungroth)
+						voterCounterSlider.GetComponent<Slider>().value = 12;
+					}
+
+					voterCounterSlider.GetComponent<Slider>().maxValue = 27;
+				}
+				else
+				{
+					voterCounterSlider.GetComponent<Slider>().maxValue = 50;
+				}
 			}
 
 			if(toggleRounds[i].isOn == true)
@@ -236,6 +252,7 @@ public class TitleScreenUIScript : MonoBehaviour
 		voterCounterButtonText.text = "40";
 
 		//resets the sliders (Alex Jungroth)
+		voterCounterSlider.GetComponent<Slider>().maxValue = 50;
 		voterCounterSlider.GetComponent<Slider>().value = 40;
 		sFXSlider.GetComponent<Slider>().value = 0.5f;
 		musicSlider.GetComponent<Slider>().value = 0.5f;


### PR DESCRIPTION
When the user chooses a 3X3X3 grid, it changes the slider for the number of voters so that its max is 27 since that grid size can only hold 27 voters. If the player had a number picked that was greater than 27 it will change the number of voters to 12 so the user doesn't accidentally start with a board full of voters. 
